### PR TITLE
Lower required macOS target to 10.10

### DIFF
--- a/ACBTokenField.podspec
+++ b/ACBTokenField.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ACBTokenField"
-  s.version      = "2.0"
+  s.version      = "2.1"
   s.summary      = "A swift extension on NSTokenField which makes it highly customizable and removes a lot of boilerplate code from implementation."
   s.description  = <<-DESC
   A swift extension on NSTokenField which makes it highly customizable and removes a lot of boilerplate code from implementation. Major features are: No need to subclass/or change anything in XIB/Storyboard. Added few properties which makes it customizable such as `shouldDisplayClearButton`, `shouldDisplaySearchIcon`, `leftView`, `shouldEnableTokenMenu` etc.. No need to implement delegate methods for simpler use cases. Just set an array of token names list or provide a default list of tokens for all indices. Rest will be handled by `NSTokenField`. Supports `NSTokenFieldDelegate` as well with the customization. Just set `tokenDelegate` and implement the methods as usual. Added support for getting `selectedTokenIndex` so that tokens can be customized based on the index. `tokenIndex` provided in `NSTokenFieldDelegate` method has a bug and hence always returns zero. `selectedTokenIndex` will help in the meantime. Support for adding tokens. Support for resetting tokens. Get `tokenIndex` based on the `representedObject` param in delegate methods.
@@ -8,8 +8,8 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/akhilcb/ACBTokenField"
   s.license      = "MIT"
   s.author    	 = "Akhil"
-  s.platform     = :osx, '10.12'
-  s.source       = { :git => "https://github.com/akhilcb/ACBTokenField.git", :tag => "2.0" }
+  s.platform     = :osx, '10.10'
+  s.source       = { :git => "https://github.com/akhilcb/ACBTokenField.git", :tag => "2.1" }
   s.source_files  = "ACBTokenField", "ACBTokenField/Classes/Source/**/*.{swift}"
   s.resources = "ACBTokenField/Resources/Assets.xcassets"
 end

--- a/ACBTokenField.xcodeproj/project.pbxproj
+++ b/ACBTokenField.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 				INFOPLIST_FILE = ACBTokenFieldFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.akhil.ACBTokenFieldFramework;
 				PRODUCT_NAME = ACBTokenField;
 				SKIP_INSTALL = YES;
@@ -471,7 +471,7 @@
 				INFOPLIST_FILE = ACBTokenFieldFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.akhil.ACBTokenFieldFramework;
 				PRODUCT_NAME = ACBTokenField;
 				SKIP_INSTALL = YES;

--- a/ACBTokenField/Classes/Source/Extensions/NSTokenField+ACBExtension.swift
+++ b/ACBTokenField/Classes/Source/Extensions/NSTokenField+ACBExtension.swift
@@ -150,9 +150,10 @@ extension NSTokenField {
     fileprivate var clearButton: NSButton {
         get {
             return associated(key: &Keys.clearButton) {
-                let button = NSButton(image: NSImage(named: self.clearIconName)!,
-                                      target: self,
-                                      action: #selector(self.clearButtonTapped(_:)))
+                let button = NSButton()
+                button.image = NSImage(named: self.clearIconName)
+                button.target = self
+                button.action = #selector(self.clearButtonTapped(_:))
                 button.setButtonType(NSButtonType.momentaryChange)
                 button.isBordered = false
                 return button
@@ -216,7 +217,8 @@ extension NSTokenField {
     }
     
     private func setupSearchIconView() {
-        let searchImageView = NSImageView(image: NSImage(named: self.searchIconName)!)
+        let searchImageView = NSImageView()
+        searchImageView.image = NSImage(named: self.searchIconName)
         self.leftView = searchImageView
     }
     

--- a/ACBTokenField/Resources/Info.plist
+++ b/ACBTokenField/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>2.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ACBTokenFieldFramework/Info.plist
+++ b/ACBTokenFieldFramework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>2.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
Hello, thank you for this library! I've been wanting for something like this for quite awhile, and had it on my to-do list! The standard NSTokenField API is really hard to work with.

I'm just getting started using the library, but the macOS 10.12 requirement gave me trouble. I changed the **framework target** requirement to 10.10, which only required changing a few NSImageView/NSButton initializers. The demo/app is still targeting 10.12. 

Everything appears to work correctly, I tested the pod with `pod 'ACBTokenField', :git => 'https://github.com/rudedogg/ACBTokenField.git'`, in an app with a 10.11 target and I can import the library now.

I also ran `pod lib lint` and got back 
```shell
 -> ACBTokenField (2.1)

ACBTokenField passed validation.
```

I also bumped the pod version etc, hopefully I've done all that correctly. Let me know if you'd like any changes, or if this isn't something you want to change I can always use my fork.

Thanks again!